### PR TITLE
fix: switch to alpine image to avoid x509 error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build \
     -o relay \
     main.go
 
-FROM scratch
+FROM alpine:3.16.2
 
 WORKDIR /app
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,14 @@
-# relay
+# Relay
 
 A dead simple web server for forwarding GitHub webhook based on filters.
 
 As of now, only relaying push events with ref filter to Lark is supported.
+
+# Configure GitHub webhook
+
+Make sure to set the webhook content type as `application/json`.
+
+# Run
 
 ```sh
 $ go run main.go --ref-prefix="refs/heads/release/" --lark-url="https://open.feishu.cn/open-apis/bot/v2/hook/xxxxxxxxxxxxxxxxx"

--- a/main.go
+++ b/main.go
@@ -48,7 +48,7 @@ func main() {
 		if !strings.HasPrefix(payload.Ref, *refPrefix) {
 			// We don't want to fail the delivery entirely since it would make the webhook
 			// look like not working on the GitHub interface.
-			return http.StatusAccepted, fmt.Sprintf(`The "ref" does not have the required prefix %q`, *refPrefix)
+			return http.StatusAccepted, fmt.Sprintf(`The ref %q does not have the required prefix %q`, payload.Ref, *refPrefix)
 		}
 
 		err = sendToLark(r.Context(), *larkURL, fmt.Sprintf("New commits have been pushed to %q: %s", payload.Ref, payload.Compare))


### PR DESCRIPTION
Current error

`Failed to send to Lark: do request: Post "https://open.feishu.cn/open-apis/bot/v2/hook/d9586e6c-ebbc-48f4-a33a-ae41d73471e0": x509: certificate signed by unknown authority`

The scratch image does not contain the CA cert.