### PR TITLE
fix: if certain flag is missing, we will only complain when it’s being used

### DIFF
--- a/hook/gerrit.go
+++ b/hook/gerrit.go
@@ -43,11 +43,26 @@ type gerritHooker struct {
 }
 
 func (hooker *gerritHooker) handler() (func(r *http.Request) Response, error) {
-	if gerritURL == "" || gerritAccount == "" || gerritPassword == "" {
-		return nil, fmt.Errorf(`the "--gerrit-url, --gerrit-account and --gerrit-password" is required`)
-	}
-
 	return func(r *http.Request) Response {
+		if gerritURL == "" {
+			return Response{
+				httpCode: http.StatusAccepted,
+				detail:   fmt.Sprintf("Skip, --gerrit-url is not set"),
+			}
+		}
+		if gerritAccount == "" {
+			return Response{
+				httpCode: http.StatusAccepted,
+				detail:   fmt.Sprintf("Skip, --gerrit-account is not set"),
+			}
+		}
+		if gerritPassword == "" {
+			return Response{
+				httpCode: http.StatusAccepted,
+				detail:   fmt.Sprintf("Skip, --gerrit-password is not set"),
+			}
+		}
+
 		var message payload.GerritEvent
 		err := json.NewDecoder(r.Body).Decode(&message)
 		if err != nil {

--- a/hook/gerrit.go
+++ b/hook/gerrit.go
@@ -47,19 +47,19 @@ func (hooker *gerritHooker) handler() (func(r *http.Request) Response, error) {
 		if gerritURL == "" {
 			return Response{
 				httpCode: http.StatusAccepted,
-				detail:   fmt.Sprintf("Skip, --gerrit-url is not set"),
+				detail:   "Skip, --gerrit-url is not set",
 			}
 		}
 		if gerritAccount == "" {
 			return Response{
 				httpCode: http.StatusAccepted,
-				detail:   fmt.Sprintf("Skip, --gerrit-account is not set"),
+				detail:   "Skip, --gerrit-account is not set",
 			}
 		}
 		if gerritPassword == "" {
 			return Response{
 				httpCode: http.StatusAccepted,
-				detail:   fmt.Sprintf("Skip, --gerrit-password is not set"),
+				detail:   "Skip, --gerrit-password is not set",
 			}
 		}
 

--- a/main.go
+++ b/main.go
@@ -60,7 +60,7 @@ func main() {
 		h = fields[0]
 		port, err := strconv.Atoi(fields[1])
 		if err != nil {
-			fmt.Printf("Port is not a number: %s", fields[1])
+			fmt.Printf("Port is not a number: %s\n", fields[1])
 			os.Exit(1)
 		}
 		p = port

--- a/sink/bytebase.go
+++ b/sink/bytebase.go
@@ -59,8 +59,17 @@ type migrationInfo struct {
 }
 
 func (sinker *bytebaseSinker) Mount() error {
-	if bytebaseURL == "" || bytebaseServiceAccount == "" || bytebaseServiceKey == "" {
-		return fmt.Errorf(`the "--bytebase-url, --bytebase-service-account and --bytebase-service-key" is required`)
+	if bytebaseURL == "" {
+		fmt.Printf("--bytebase-url is missing, Bytebase sinker will not be able to process any events.\n")
+		return nil
+	}
+	if bytebaseServiceAccount == "" {
+		fmt.Printf("--bytebase-service-account is missing, Bytebase sinker will not be able to process any events.\n")
+		return nil
+	}
+	if bytebaseServiceKey == "" {
+		fmt.Printf("---bytebase-service-key is missing, Bytebase sinker will not be able to process any events.\n")
+		return nil
 	}
 
 	sinker.bytebaseService = service.NewBytebase(bytebaseURL, bytebaseServiceAccount, bytebaseServiceKey)
@@ -68,6 +77,16 @@ func (sinker *bytebaseSinker) Mount() error {
 }
 
 func (sinker *bytebaseSinker) Process(c context.Context, _ string, pi interface{}) error {
+	if bytebaseURL == "" {
+		return fmt.Errorf("--bytebase-url is required")
+	}
+	if bytebaseServiceAccount == "" {
+		return fmt.Errorf("--bytebase-service-account is required")
+	}
+	if bytebaseServiceKey == "" {
+		return fmt.Errorf("---bytebase-service-key is required")
+	}
+
 	change := pi.(payload.GerritFileChangeMessage)
 
 	for _, file := range change.Files {

--- a/sink/lark.go
+++ b/sink/lark.go
@@ -38,12 +38,15 @@ type larkSinker struct {
 
 func (sinker *larkSinker) Mount() error {
 	if webhookURLs == "" {
-		return fmt.Errorf(`the "--lark-urls" is required`)
+		fmt.Printf("--lark-urls is missing, Lark sinker will not be able to process any events.\n")
 	}
 	return nil
 }
 
 func (sinker *larkSinker) Process(c context.Context, path string, pi interface{}) error {
+	if webhookURLs == "" {
+		return fmt.Errorf("--lark-urls is required")
+	}
 	switch path {
 	case "/github":
 		p := pi.(payload.GitHubPushEvent)


### PR DESCRIPTION
![CleanShot 2023-02-19 at 00-21-08 png](https://user-images.githubusercontent.com/230323/219876631-be159218-5353-4cdf-b740-8ccab982597c.png)

Just print a warning on start-up if flag is missing, while we mount the handler/sinker. Instead of fail the whole application upon startup.

Thus it won't force to specify all flags every time